### PR TITLE
Fix syntax error

### DIFF
--- a/technology/ansible.md
+++ b/technology/ansible.md
@@ -41,7 +41,7 @@ $ ansible -i hosts all -u centos -s -m shell -a "rm -rf /"
 
 ```
 import logging
-logging.basicConfig(filename="/tmp/ansible-debug.log', level=logging.DEBUG)
+logging.basicConfig(filename="/tmp/ansible-debug.log", level=logging.DEBUG)
 ```
 
 Somewhere else in the code do:


### PR DESCRIPTION
Double quote (`"`) instead single quote (`'`) for terminating string literal.

```py
logging.basicConfig(filename="/tmp/ansible-debug.log', level=logging.DEBUG)
````
to
```py
logging.basicConfig(filename="/tmp/ansible-debug.log", level=logging.DEBUG)
````